### PR TITLE
Revived dockerfile

### DIFF
--- a/400-nominatim.conf
+++ b/400-nominatim.conf
@@ -1,7 +1,5 @@
 Listen 8080
 <VirtualHost *:8080>
-        ServerName localhost
-        ServerAdmin root@example.com
         DocumentRoot /var/www/nominatim
         CustomLog /var/log/apache2/access.log combined
         ErrorLog /var/log/apache2/error.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN apt-get -y install php5 php-pear php5-pgsql php5-json php-db
 # Install Postgres, PostGIS and dependencies
 RUN apt-get -y install postgresql postgis postgresql-contrib postgresql-9.3-postgis-2.1 postgresql-server-dev-9.3
 
+# Work around for AUFS bug as per https://github.com/docker/docker/issues/783#issuecomment-56013588
+RUN mkdir /etc/ssl/private-copy; mv /etc/ssl/private/* /etc/ssl/private-copy/; rm -r /etc/ssl/private; mv /etc/ssl/private-copy /etc/ssl/private; chmod -R 0700 /etc/ssl/private; chown -R postgres /etc/ssl/private
 
 # Some additional packages that may not already be installed
 # bc is needed in configPostgresql.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,6 @@ EXPOSE 5432
 
 RUN apt-get install -y curl
 ADD 400-nominatim.conf /etc/apache2/sites-available/400-nominatim.conf
-ADD httpd.conf /etc/apache2/
 RUN service apache2 start && \
   a2ensite 400-nominatim.conf && \
   /etc/init.d/apache2 reload

--- a/httpd.conf
+++ b/httpd.conf
@@ -1,1 +1,0 @@
-ServerName localhost

--- a/local.php
+++ b/local.php
@@ -3,7 +3,7 @@
  @define('CONST_Postgresql_Version', '9.3');
  @define('CONST_Postgis_Version', '2.1');
  // Website settings
- @define('CONST_Website_BaseURL', 'http://localhost:8080/');
+ @define('CONST_Website_BaseURL', '/');
  @define('CONST_Replication_Url', 'http://download.geofabrik.de/europe-updates');
  @define('CONST_Replication_MaxInterval', '86400');     // Process each update separately, osmosis cannot merge multiple updates
  @define('CONST_Replication_Update_Interval', '86400');  // How often upstream publishes diffs


### PR DESCRIPTION
1. Fix private key file permission error after postgres install.
2. Now you can run container on any host and port (not only localhost).
