### PR TITLE
Fix: initial import of country_osm_grid.sql.gz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,11 +64,11 @@ RUN sudo -u postgres /usr/lib/postgresql/9.3/bin/pg_ctl start -w -D /etc/postgre
   sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='www-data'" | grep -q 1 || sudo -u postgres createuser -SDR www-data && \
   sudo -u postgres psql postgres -c "DROP DATABASE IF EXISTS nominatim"
 
-RUN wget --output-document=/app/git/data/country_osm_grid.sql.gz http://www.nominatim.org/data/country_grid.sql.gz
-RUN wget --output-document=/app/data.pbf $OSM
-# RUN wget --output-document=/app/data.pbf http://download.geofabrik.de/europe/luxembourg-latest.osm.pbf
-# RUN wget --output-document=/app/data.pbf http://download.geofabrik.de/north-america-latest.osm.pbf
-# RUN wget --output-document=/app/data.pbf http://download.geofabrik.de/north-america/us/delaware-latest.osm.pbf
+RUN wget --timestamping --output-document=/app/git/data/country_osm_grid.sql.gz http://www.nominatim.org/data/country_grid.sql.gz
+RUN wget --timestamping --output-document=/app/data.pbf $OSM
+# RUN wget --timestamping --output-document=/app/data.pbf http://download.geofabrik.de/europe/luxembourg-latest.osm.pbf
+# RUN wget --timestamping --output-document=/app/data.pbf http://download.geofabrik.de/north-america-latest.osm.pbf
+# RUN wget --timestamping --output-document=/app/data.pbf http://download.geofabrik.de/north-america/us/delaware-latest.osm.pbf
 
 WORKDIR /app/nominatim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,6 +64,7 @@ RUN sudo -u postgres /usr/lib/postgresql/9.3/bin/pg_ctl start -w -D /etc/postgre
   sudo -u postgres psql postgres -tAc "SELECT 1 FROM pg_roles WHERE rolname='www-data'" | grep -q 1 || sudo -u postgres createuser -SDR www-data && \
   sudo -u postgres psql postgres -c "DROP DATABASE IF EXISTS nominatim"
 
+RUN wget --output-document=/app/git/data/country_osm_grid.sql.gz http://www.nominatim.org/data/country_grid.sql.gz
 RUN wget --output-document=/app/data.pbf $OSM
 # RUN wget --output-document=/app/data.pbf http://download.geofabrik.de/europe/luxembourg-latest.osm.pbf
 # RUN wget --output-document=/app/data.pbf http://download.geofabrik.de/north-america-latest.osm.pbf


### PR DESCRIPTION
Unless the country grid is downloaded before setting up Nominatim, the setup will fail:
`Error: you need to download the country_osm_grid first:
    wget -O /app/git/data/country_osm_grid.sql.gz http://www.nominatim.org/data/
The command '/bin/sh -c sudo -u postgres /usr/lib/postgresql/9.3/bin/pg_ctl star
hreads 2' returned a non-zero code: 1`

This PR adds a command to download this file, which allows the build to complete succcessfully.

Also, it adds a `--timestamping` option to the wget requests, so that unchanged files are not pointlessly redownloaded (only files that have been modified are downloaded again).