### PR TITLE
Fix: index.php doesn't exist - this makes the site seem nonfunctional, symlink to search.php

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,7 +81,7 @@ RUN sudo -u postgres /usr/lib/postgresql/9.3/bin/pg_ctl start -w -D /etc/postgre
   sudo -u nominatim ./utils/setup.php --osm-file /app/data.pbf --all --threads 2
 
 RUN mkdir -p /var/www/nominatim
-RUN ln -s ./search.php /app/nominatim/website/index.php
+RUN ln -s ./search.php /app/nominatim/website/index.php || true
 RUN cp -R /app/nominatim/website /var/www/nominatim/
 RUN cp -R /app/nominatim/settings /var/www/nominatim/
 RUN chown -R nominatim:www-data /var/www/nominatim

--- a/Dockerfile
+++ b/Dockerfile
@@ -81,6 +81,7 @@ RUN sudo -u postgres /usr/lib/postgresql/9.3/bin/pg_ctl start -w -D /etc/postgre
   sudo -u nominatim ./utils/setup.php --osm-file /app/data.pbf --all --threads 2
 
 RUN mkdir -p /var/www/nominatim
+RUN ln -s ./search.php /app/nominatim/website/index.php
 RUN cp -R /app/nominatim/website /var/www/nominatim/
 RUN cp -R /app/nominatim/settings /var/www/nominatim/
 RUN chown -R nominatim:www-data /var/www/nominatim


### PR DESCRIPTION
- until this is fixed upstream, hack around the limitation by making a symlink from index.php to search.php 